### PR TITLE
Add entity name into label translation strategy

### DIFF
--- a/src/Admin/CoreAdmin.php
+++ b/src/Admin/CoreAdmin.php
@@ -45,6 +45,16 @@ abstract class CoreAdmin extends SonataAdmin implements \JsonSerializable
     protected $extraTemplates = [];
 
     /**
+     * {@inheritdoc}
+     */
+    public function getLabelTranslatorStrategy()
+    {
+        $this->labelTranslatorStrategy->setAdmin($this);
+
+        return $this->labelTranslatorStrategy;
+    }
+
+    /**
      * Configure routes for list actions.
      *
      * @param RouteCollection $collection

--- a/src/Translator/LibrinfoLabelTranslatorStrategy.php
+++ b/src/Translator/LibrinfoLabelTranslatorStrategy.php
@@ -25,6 +25,8 @@ use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
  */
 class LibrinfoLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
+    private $admin;
+
     /**
      * {@inheritdoc}
      */
@@ -32,6 +34,26 @@ class LibrinfoLabelTranslatorStrategy implements LabelTranslatorStrategyInterfac
     {
         $label = str_replace('.', '_', $label);
 
-        return sprintf('%s.%s.%s', 'librinfo', $type, strtolower(preg_replace('~(?<=\\w)([A-Z])~', '_$1', $label)));
+        return sprintf('%s.%s.%s.%s', 'librinfo', $type, strtolower(preg_replace('~(?<=\\w)([A-Z])~', '_$1', $this->getAdmin()->getClassnameLabel())), strtolower(preg_replace('~(?<=\\w)([A-Z])~', '_$1', $label)));
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @param mixed admin
+     *
+     * @return self
+     */
+    public function setAdmin($admin)
+    {
+        $this->admin = $admin;
+
+        return $this;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Tests pass?   | yes
| License       | LGPL

Modify custom label strategy to add entity name in order to differentiate commons label by entity (ex: code wouldn't be the same translation between 2 slightly different entities.)